### PR TITLE
changed the trigger from main to devel as the branch name changed

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ name: Github Pages Astro CI
 on:
   # Triggers the workflow on push and pull request events but only for the main branch
   push:
-    branches: [main]
+    branches: [devel]
 
   # Allows you to run this workflow manually from the Actions tab.
   workflow_dispatch:


### PR DESCRIPTION
changed the github actions trigger for building the site from `main` to `devel` as the default branch name was changed in the github